### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [development, master]
 
+permissions:
+  contents: read
+
 jobs:
   scan_ruby:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/m4rcelotoledo/deals/security/code-scanning/1](https://github.com/m4rcelotoledo/deals/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/ruby.yml`, directly under `on:` (or before `jobs:`), so all jobs inherit minimal token access unless overridden.

Best fix here without changing behavior: set:

- `permissions:`
  - `contents: read`

This is the CodeQL-recommended minimal baseline and is sufficient for checkout/read-oriented CI tasks shown here. If a specific job later needs extra scopes, add job-level overrides then.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
